### PR TITLE
Simon/c3 usb jtag repl fix

### DIFF
--- a/targets/esp32/jshardware.c
+++ b/targets/esp32/jshardware.c
@@ -66,6 +66,9 @@
 #include "rom/uart.h"
 #include "driver/gpio.h"
 #include "soc/gpio_sig_map.h"
+#ifdef ESPR_USE_USB_SERIAL_JTAG
+#include "driver/usb_serial_jtag.h"
+#endif
 
 #if ESP_IDF_VERSION_MAJOR>=5
 #include "esp_flash.h"
@@ -631,7 +634,11 @@ void jshUSARTSetup(IOEventFlags device, JshUSARTInfo *inf) {
 }
 
 bool jshIsUSBSERIALConnected() {
+#ifdef ESPR_USE_USB_SERIAL_JTAG
+  return usb_serial_jtag_is_driver_installed() && usb_serial_jtag_is_connected();
+#else
   return false; // "On non-USB boards this just returns false"
+#endif
 }
 
 /**
@@ -648,9 +655,20 @@ void jshUSARTKick(IOEventFlags device) {
       break;
 #endif
     case EV_SERIAL1:
-      uart_tx_one_char((uint8_t)c);
 #ifdef ESPR_USE_USB_SERIAL_JTAG
-      // The USB CDC UART on the C3 only writes the data to USB after a newline. Ensure uartTask in main.c knows to flush the UART next time
+      {
+        uint8_t ch = (uint8_t)c;
+        if (usb_serial_jtag_is_driver_installed()) {
+          usb_serial_jtag_write_bytes(&ch, 1, 0);
+        } else {
+          uart_tx_one_char(ch);
+        }
+      }
+#else
+      uart_tx_one_char((uint8_t)c);
+#endif
+#ifdef ESPR_USE_USB_SERIAL_JTAG
+      // Ensure uartTask in main.c knows to wait for pending USB Serial/JTAG TX to complete.
       extern void esp32USBUARTWasUsed();
       esp32USBUARTWasUsed();
 #endif

--- a/targets/esp32/jshardware.c
+++ b/targets/esp32/jshardware.c
@@ -67,7 +67,11 @@
 #include "driver/gpio.h"
 #include "soc/gpio_sig_map.h"
 #ifdef ESPR_USE_USB_SERIAL_JTAG
+#if ESP_IDF_VERSION_MAJOR>=5
 #include "driver/usb_serial_jtag.h"
+#elif ESP_IDF_VERSION_MAJOR==4
+#include "hal/usb_serial_jtag_ll.h"
+#endif
 #endif
 
 #if ESP_IDF_VERSION_MAJOR>=5
@@ -635,7 +639,11 @@ void jshUSARTSetup(IOEventFlags device, JshUSARTInfo *inf) {
 
 bool jshIsUSBSERIALConnected() {
 #ifdef ESPR_USE_USB_SERIAL_JTAG
+#if ESP_IDF_VERSION_MAJOR>=5
   return usb_serial_jtag_is_driver_installed() && usb_serial_jtag_is_connected();
+#else
+  return false;
+#endif
 #else
   return false; // "On non-USB boards this just returns false"
 #endif
@@ -658,11 +666,15 @@ void jshUSARTKick(IOEventFlags device) {
 #ifdef ESPR_USE_USB_SERIAL_JTAG
       {
         uint8_t ch = (uint8_t)c;
+#if ESP_IDF_VERSION_MAJOR>=5
         if (usb_serial_jtag_is_driver_installed()) {
           usb_serial_jtag_write_bytes(&ch, 1, 0);
         } else {
           uart_tx_one_char(ch);
         }
+#else
+        uart_tx_one_char(ch);
+#endif
       }
 #else
       uart_tx_one_char((uint8_t)c);

--- a/targets/esp32/jshardwareUart.c
+++ b/targets/esp32/jshardwareUart.c
@@ -104,14 +104,19 @@ void initSerial(IOEventFlags device, JshUSARTInfo *inf){
 void initConsole(){
 #ifdef ESPR_USE_USB_SERIAL_JTAG
   /* Configure USB-CDC driver */
+  usb_serial_jtag_driver_config_t usb_serial_config = {
+    .tx_buffer_size = 128,
+    .rx_buffer_size = 128
+  };
+#if ESP_IDF_VERSION_MAJOR>=5
   if (!usb_serial_jtag_is_driver_installed()) {
-    usb_serial_jtag_driver_config_t usb_serial_config = {
-      .tx_buffer_size = 128,
-      .rx_buffer_size = 128
-    };
     jsDebug(DBG_INFO, "initConsole: Installing usb_serial_jtag_driver\n");
     ESP_ERROR_CHECK(usb_serial_jtag_driver_install(&usb_serial_config));
   }
+#else
+  jsDebug(DBG_INFO, "initConsole: Installing usb_serial_jtag_driver\n");
+  ESP_ERROR_CHECK(usb_serial_jtag_driver_install(&usb_serial_config));
+#endif
 #endif
   uart_config_t uart_config = {
     .baud_rate = 115200,

--- a/targets/esp32/jshardwareUart.c
+++ b/targets/esp32/jshardwareUart.c
@@ -104,12 +104,14 @@ void initSerial(IOEventFlags device, JshUSARTInfo *inf){
 void initConsole(){
 #ifdef ESPR_USE_USB_SERIAL_JTAG
   /* Configure USB-CDC driver */
-  usb_serial_jtag_driver_config_t usb_serial_config = {
-    .tx_buffer_size = 128,
-    .rx_buffer_size = 128
-  };
-  jsDebug(DBG_INFO, "initConsole: Installing usb_serial_jtag_driver\n");
-  ESP_ERROR_CHECK(usb_serial_jtag_driver_install(&usb_serial_config));
+  if (!usb_serial_jtag_is_driver_installed()) {
+    usb_serial_jtag_driver_config_t usb_serial_config = {
+      .tx_buffer_size = 128,
+      .rx_buffer_size = 128
+    };
+    jsDebug(DBG_INFO, "initConsole: Installing usb_serial_jtag_driver\n");
+    ESP_ERROR_CHECK(usb_serial_jtag_driver_install(&usb_serial_config));
+  }
 #endif
   uart_config_t uart_config = {
     .baud_rate = 115200,

--- a/targets/esp32/main.c
+++ b/targets/esp32/main.c
@@ -93,11 +93,11 @@ static void uartTask(void *data) {
     consoleToEspruino();
     serialToEspruino();
 #ifdef ESPR_USE_USB_SERIAL_JTAG
-    /* The USB CDC UART on the C3 only writes the data to USB after a newline.
-    We don't want that, so we call flush in this uart task if any data has been sent. */
+    /* Espruino writes console output outside stdio, so explicitly wait for the
+    USB Serial/JTAG driver to drain any queued TX bytes. */
     if (usbUARTIsNotFlushed) {
     #if ESP_IDF_VERSION_MAJOR >= 5
-      fflush(stdout);  // Or fsync(1);
+      usb_serial_jtag_wait_tx_done(pdMS_TO_TICKS(10));
     #else
       usb_serial_jtag_ll_txfifo_flush();
     #endif


### PR DESCRIPTION
## ESP32C3_IDF5: USB Serial/JTAG REPL output still uses UART TX path

** Observed on ESP32-C3 hardware in Espruino WEBIDE** 
Found ESP32C3_IDF5. Espruino banner appears and > prompt is shown
after connecting over Web Serial, an extra Enter is needed before the prompt behaves normally
keyboard input is not echoed per-character until newline is sent

** Root cause:**

RX is already using the USB Serial/JTAG driver path
EV_SERIAL1 TX still goes through uart_tx_one_char(...)
the console task flush path still uses stdio flush rather than the USB Serial/JTAG driver wait

**Fix that worked here:**

use usb_serial_jtag_write_bytes(...) for EV_SERIAL1 when ESPR_USE_USB_SERIAL_JTAG is enabled
use usb_serial_jtag_wait_tx_done(...) in the console flush path
avoid reinstalling the USB Serial/JTAG driver if it is already present
report the actual USB Serial/JTAG connection state

**Validation:**

tested on ESP32-C3 over /dev/ttyACM0

AI Agent retested through Chrome Web Serial
prompt appears on connect without extra input
per-character echo is immediate
normal REPL interaction works again

Interactive test Espruino WebIDE confirms proper behavior