### PR TITLE
ESP32S3_IDF5: keep native USB pins untouched at startup

### DIFF
--- a/targets/esp32/jshardware.c
+++ b/targets/esp32/jshardware.c
@@ -133,7 +133,7 @@ void IRAM_ATTR gpio_intr_handler(void* arg){
 #endif
   SET_PERI_REG_MASK(GPIO_STATUS_W1TC_REG, gpio_intr_status);    //Clear intr for gpio0-gpio31
 #ifndef CONFIG_IDF_TARGET_ESP32C3
-  SET_PERI_REG_MASK(GPIO_STATUS1_W1TC_REG, gpio_intr_status_h); //Clear intr for gpio32-39
+  SET_PERI_REG_MASK(GPIO_STATUS1_W1TC_REG, gpio_intr_status_h); //Clear intr for gpio32-gpio39
 #endif
 
   do {
@@ -169,7 +169,13 @@ void jshPinDefaultPullup() {
   // 34-39 are input-only 
   jshPinSetStateRange(0,0,JSHPINSTATE_GPIO_IN_PULLUP);
   jshPinSetStateRange(12,15,JSHPINSTATE_GPIO_IN_PULLUP);
+#ifdef CONFIG_IDF_TARGET_ESP32S3
+  // GPIO19/20 are native USB D-/D+ on ESP32-S3. Reconfiguring them can
+  // disable the USB Serial/JTAG device.
+  jshPinSetStateRange(18,18,JSHPINSTATE_GPIO_IN_PULLUP);
+#else
   jshPinSetStateRange(18,19,JSHPINSTATE_GPIO_IN_PULLUP);
+#endif
   jshPinSetStateRange(21,22,JSHPINSTATE_GPIO_IN_PULLUP);
   jshPinSetStateRange(25,27,JSHPINSTATE_GPIO_IN_PULLUP);
 #endif


### PR DESCRIPTION
## Issue 2
ESP32S3_IDF5: startup pull-up init reconfigures native USB pin GPIO19

Native USB Serial/JTAG REPL on ESP32S3_IDF5 disappears after boot on real hardware even though the build and flash complete successfully.

** Observed on an Olimex ESP32-S3-DevKit-Lipo:**

flash succeeds
the native USB/JTAG port enumerates as /dev/ttyACM0
after boot there is no prompt, no echo, and no usable REPL traffic

Important control case:
the plain ESP-IDF 5 usb_serial_jtag_echo example works on the same board
that points to an Espruino startup interaction rather than a general ESP-IDF 5 USB/JTAG failure

**Root Cause: **

jshPinDefaultPullup() applies default pull-up configuration to GPIO 18-19
on ESP32-S3, GPIO19/20 are the native USB D-/D+ pins
touching GPIO19 during startup can disable the USB Serial/JTAG device

**Fix that worked here:**

special-case ESP32-S3 in jshPinDefaultPullup()
avoid reconfiguring GPIO19/20 during startup

**Validation:**

tested on a  Olimex ESP32-S3-DevKit-Lipo
flashed over the UART bridge
native USB/JTAG on /dev/ttyACM0 remained alive after boot
prompt and per-character REPL echo both worked again