### PR TITLE
Fix/esp32 idf5 digitalpulse target v2

### DIFF
--- a/targets/esp32/jshardware.c
+++ b/targets/esp32/jshardware.c
@@ -34,9 +34,8 @@
 #include "rtosutil.h"
 #if ESP_IDF_VERSION_MAJOR>=5
 #include "driver/gptimer.h"
-#else
-#include "driver/timer.h"
 #endif
+#include "driver/timer.h"
 
 #ifdef BLUETOOTH
 #include "BLE/esp32_gap_func.h"
@@ -743,26 +742,20 @@ void jshSetSystemTime(JsSysTime newTime) {
   tz.tz_dsttime=0;
   settimeofday(&tm, &tz);
 }
-#if ESP_IDF_VERSION_MAJOR>=5
-  void jshUtilTimerDisable() {}
-  void jshUtilTimerStart(JsSysTime period) {}
-  void jshUtilTimerReschedule(JsSysTime period) {}
-#else
-  void jshUtilTimerDisable() {
-    timer_pause(TIMER_GROUP_0, 0);
-    timer_disable_intr(TIMER_GROUP_0, 0);
-  }
+void jshUtilTimerDisable() {
+  timer_pause(TIMER_GROUP_0, 0);
+  timer_disable_intr(TIMER_GROUP_0, 0);
+}
 
-  void jshUtilTimerStart(JsSysTime period) {
-    if(period <= 30){period = 30;}
-    timer_Start(0, period);
-  }
+void jshUtilTimerStart(JsSysTime period) {
+  if (period <= 30) period = 30;
+  timer_Start(0, period);
+}
 
-  void jshUtilTimerReschedule(JsSysTime period) {
-    if(period <= 30){period = 30;}
-    timer_Reschedule(0,(uint64_t)period);
-  }
-#endif
+void jshUtilTimerReschedule(JsSysTime period) {
+  if (period <= 30) period = 30;
+  timer_Reschedule(0, (uint64_t)period);
+}
 
 //===== Miscellaneous =====
 

--- a/targets/esp32/rtosutil.c
+++ b/targets/esp32/rtosutil.c
@@ -174,8 +174,13 @@ void timer_Reschedule(int idx, uint64_t duration) {
   int timer_n = ESP32Timers[idx].index;
   
   if (duration < TIMER_FINE_ADJ + 1) duration = TIMER_FINE_ADJ + 1;
+#if ESP_IDF_VERSION_MAJOR >= 5
+  timer_group_set_alarm_value_in_isr(group, timer_n, duration - TIMER_FINE_ADJ);
+  timer_group_enable_alarm_in_isr(group, timer_n);
+#else
   timer_set_alarm_value(group, timer_n, duration - TIMER_FINE_ADJ);
   TIMER_ALARM_EN(timer_n);
+#endif
 }
 
 void timer_List() {

--- a/targets/esp32/rtosutil.c
+++ b/targets/esp32/rtosutil.c
@@ -29,12 +29,12 @@ ESP32Timer_t ESP32Timers[timerMax];
 #endif
 
 #define TIMER_DIVIDER 80
-#define TIMER_FINE_ADJ   (1.4f*(TIMER_BASE_CLK / TIMER_DIVIDER)/1000000.0f)
+#define TIMER_FINE_ADJ   (((14ULL * (uint64_t)TIMER_BASE_CLK) + (10ULL * TIMER_DIVIDER * 1000000ULL) - 1) / (10ULL * TIMER_DIVIDER * 1000000ULL))
 #define TIMER_INTR_SEL   TIMER_INTR_LEVEL
 
 // Universal ESP32 timer macros - IDF 3.x/4.x/5.x compatible
 #if CONFIG_IDF_TARGET_ESP32
-  #define TIMER_FINE_ADJ   (1.4f*(TIMER_BASE_CLK / TIMER_DIVIDER)/1000000.0f)
+  #define TIMER_FINE_ADJ   (((14ULL * (uint64_t)TIMER_BASE_CLK) + (10ULL * TIMER_DIVIDER * 1000000ULL) - 1) / (10ULL * TIMER_DIVIDER * 1000000ULL))
   #if ESP_IDF_VERSION_MAJOR>=5
     // IDF5 ESP32 - CORRECT field names from compiler hint
     #define TIMER_TX_UPDATE(TIMER_N)  (TIMERG0.hw_timer[TIMER_N].update.tx_update = 1)
@@ -49,12 +49,12 @@ ESP32Timer_t ESP32Timers[timerMax];
     #define TIMER_1_INT_CLR()         (TIMERG0.int_clr_timers.t1 = 1)
   #endif
 #elif CONFIG_IDF_TARGET_ESP32C3
-  #define TIMER_FINE_ADJ   (1.4*(esp_clk_apb_freq() / TIMER_DIVIDER)/1000000)
+  #define TIMER_FINE_ADJ   (((14ULL * (uint64_t)esp_clk_apb_freq()) + (10ULL * TIMER_DIVIDER * 1000000ULL) - 1) / (10ULL * TIMER_DIVIDER * 1000000ULL))
   #define TIMER_TX_UPDATE(TIMER_N) (TIMERG0.hw_timer[TIMER_N].update.tx_update = 1)
   #define TIMER_ALARM_EN(TIMER_N)  (TIMERG0.hw_timer[TIMER_N].config.tx_alarm_en = 1)
   #define TIMER_0_INT_CLR()        (TIMERG0.int_clr_timers.t0_int_clr = 1)
 #elif CONFIG_IDF_TARGET_ESP32S3
-  #define TIMER_FINE_ADJ   (1.4*(esp_clk_apb_freq() / TIMER_DIVIDER)/1000000)
+  #define TIMER_FINE_ADJ   (((14ULL * (uint64_t)esp_clk_apb_freq()) + (10ULL * TIMER_DIVIDER * 1000000ULL) - 1) / (10ULL * TIMER_DIVIDER * 1000000ULL))
   #define TIMER_TX_UPDATE(TIMER_N) (TIMERG0.hw_timer[TIMER_N].update.tn_update = 1)
   #define TIMER_ALARM_EN(TIMER_N)  (TIMERG0.hw_timer[TIMER_N].config.tn_alarm_en = 1)
   #define TIMER_0_INT_CLR()        (TIMERG0.int_clr_timers.t0_int_clr = 1)


### PR DESCRIPTION
This PR restores the ESP32 IDF5 timer path used by `digitalPulse`.

In the new IDF5  , `digitalWrite` loopback worked but `digitalPulse` did not. The
fix is limited to `targets/esp32/jshardware.c` and `targets/esp32/rtosutil.c`:
it restores the utility timer hooks, uses the IDF5-safe interrupt-side timer
alarm update path, and keeps the active reschedule path safe on original ESP32
IDF5.

Bench validation after these changes reported the expected four-edge pulse
sequence on both ESP32-C3 IDF5 and original ESP32 IDF5.

An earlier debounced watch-based test method also exposed a separate
Espruino Core debounce/watch (Edge case) issue in `src/jsinteractive.c`, but that is being
handled separately and is not part of this target-side PR.

Tested with 
```` JS
echo(false);
pinMode(D3, "output");
pinMode(D4, "input");
digitalWrite(D3, 0);

var seen = [];
var count = 0;

var w = setWatch(function(e) {
  count++;
  seen.push(e.state ? 1 : 0);
}, D4, {repeat:true, edge:"both"});

setTimeout(function() {
  digitalPulse(D3, 1, [20,20,20]);
}, 20);

setTimeout(function() {
  clearWatch(w);
  print("PULSE_SEEN=" + count);
  print("PULSE_STATES=" + JSON.stringify(seen));
  print("D4_FINAL=" + digitalRead(D4));
  echo(true);
}, 280);
````
Resulting in 
```` JS
PULSE_SEEN=4
PULSE_STATES=[1,0,1,0]
D4_FINAL=0
````